### PR TITLE
Add a copr for nss-altfiles and openvswitch

### DIFF
--- a/c9s.repo
+++ b/c9s.repo
@@ -9,3 +9,13 @@ name=UNSIGNED CentOS Stream 9 AppStream
 baseurl=https://composes.stream.centos.org/development/latest-CentOS-Stream/compose/AppStream/$basearch/os
 gpgcheck=0
 enabled=1
+
+[c9s-rt]
+baseurl=https://odcs.stream.centos.org/test/latest-CentOS-Stream/compose/RT/$basearch/os/
+gpgcheck=0
+enabled=1
+
+[c9s-nfv]
+baseurl=https://odcs.stream.centos.org/test/latest-CentOS-Stream/compose/NFV/$basearch/os/
+gpgcheck=0
+enabled=1

--- a/copr-walters-coreos-centos-stuff.repo
+++ b/copr-walters-coreos-centos-stuff.repo
@@ -1,0 +1,10 @@
+[walters-coreos-centos-stuff]
+name=Copr repo for coreos-centos-stuff owned by walters
+baseurl=https://download.copr.fedorainfracloud.org/results/walters/coreos-centos-stuff/fedora-34-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://download.copr.fedorainfracloud.org/results/walters/coreos-centos-stuff/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1

--- a/extensions.yaml
+++ b/extensions.yaml
@@ -3,8 +3,8 @@
 # and https://github.com/coreos/fedora-coreos-tracker/issues/401
 
 repos:
-  - rhel-8-advanced-virt
-  - rhel-8-nfv
+  - c9s-rt
+  - c9s-nfv
 
 extensions:
   # https://github.com/coreos/fedora-coreos-tracker/issues/326
@@ -48,8 +48,8 @@ extensions:
   # GRPA-3123
   # - kata-containers (RHAOS)
   #   - qemu-kiwi (advanced-virt)
-  sandboxed-containers:
-    architectures:
-      - x86_64
-    packages:
-      - kata-containers
+  # sandboxed-containers:
+  #   architectures:
+  #     - x86_64
+  #   packages:
+  #     - kata-containers

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -95,6 +95,8 @@ postprocess:
 
      # We're not using resolved yet
      rm -f /usr/lib/systemd/system/systemd-resolved.service
+     # C9S FIXME why is this only broken here?  NM isn't removing the link?
+     sed -i '/etc.resolv/d' /usr/lib/tmpfiles.d/etc.conf
 
      # Let's have a non-boring motd, just like CL (although theirs is more subdued
      # nowadays compared to early versions with ASCII art).  One thing we do here

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -27,6 +27,8 @@ arch-include:
 repos:
   - baseos
   - appstream
+  # For nss-altfiles
+  - walters-coreos-centos-stuff
   # - rhel-8-fast-datapath
   # - rhel-8-fast-datapath-aarch64
   - rhel-8-server-ose
@@ -198,7 +200,7 @@ packages:
  - cri-o cri-tools
  # Networking
  - nfs-utils
- # - openvswitch2.15
+ - openvswitch
  - dnsmasq
  - NetworkManager-ovs
  # Need to keep providing dhclient binary

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -193,6 +193,8 @@ packages:
  - kernel-modules-extra
  # Audit
  - audit
+ # Currently required by rpm-ostree, though honestly it shouldn't be
+ - polkit
  # Containers
  - containernetworking-plugins
  # Pinned due to cosa on Fedora not honoring RHEL 8 modules as expected

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -161,7 +161,10 @@ postprocess:
      # crio should stop hardcoding things in their config file!
      # We are apparently somehow pulling in a conmon override in RHCOS
      # that contains /usr/libexec/crio/conmon - WHY?
-     sed -i '/conmon.*=/d' /etc/crio/crio.conf
+     # sed -i '/conmon.*=/d' /etc/crio/crio.conf
+     # Oh right but the MCO overrides that too so...
+     mkdir -p /usr/libexec/crio
+     ln -sr /usr/bin/conmon /usr/libexec/crio/conmon
 
 etc-group-members:
   - wheel

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -249,7 +249,7 @@ packages:
  - openshift-hyperkube openshift-clients
  # Gluster - Used for Openshift e2e gluster testcases
  # Reverts https://gitlab.cee.redhat.com/coreos/redhat-coreos/merge_requests/367 and add it for all arches
- # - glusterfs-fuse
+ - glusterfs-fuse
  # Needed for kernel-devel extension: https://bugzilla.redhat.com/show_bug.cgi?id=1885408
  # x86_64 and s390x have these packages installed as dependencies of other packages, ppc64le does not
  # FIXME: once the below BZs have been resolved to remove perl dependencies, this can be done in the extensions script

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -150,12 +150,18 @@ postprocess:
     done
     rm -f $(which authselect)
 
-  # FIXME: Force enable dbus-broker to get the dbus.service → dbus-broker.service
+  # Misc C9S bodges
   - |
      #!/usr/bin/env bash
      set -xeuo pipefail
 
+     # FIXME - hmm I bet this is because we have an old redhat-release-coreos
+     # package that doesn't enable the preset
      systemctl enable dbus-broker
+     # crio should stop hardcoding things in their config file!
+     # We are apparently somehow pulling in a conmon override in RHCOS
+     # that contains /usr/libexec/crio/conmon - WHY?
+     sed -i '/conmon.*=/d' /etc/crio/crio.conf
 
 etc-group-members:
   - wheel


### PR DESCRIPTION
Add a copr for nss-altfiles and openvswitch

I'm working on the awesome paperwork to actually ship this in
C9S but for now let's just build it in a F34 copr which works
for `nss-altfiles`.

`openvswitch` is a whole other thing, but this hack gets us
going.

---

manifest: Explicitly add polkit

rpm-ostree currently implicitly relies on it, which is a bug
I will fix.

---

Work around systemd vs NM

How is this working in Fedora/FCOS today?

---

manifest: Fix crio conmon path

---

